### PR TITLE
Fixing Actions CI caching not working

### DIFF
--- a/.github/workflows/merge-ci.yml
+++ b/.github/workflows/merge-ci.yml
@@ -25,7 +25,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ matrix.rust-version }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
- Fixes GitHub Actions CI caching. Part of #4 which was not solved with #5.

- GitHub Actions CI now properly uses cache. Time down 75% from ~180 seconds to ~45 seconds. Cache size per rust version is ~200MB.